### PR TITLE
remove 'test' from stdout

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -15,7 +15,6 @@ bot = commands.Bot(command_prefix='!')  # way 2, you cant use both ways
 
 @bot.command(name="hello", aliases=["hi", "hey", "hallo"])
 async def world(ctx):
-    print('test')
     await ctx.send('world!')
 
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,7 +1,7 @@
 from discord.ext import commands
 import random
 
-with open("src/DISCORD_TOKEN.txt", "r") as code:
+with open("DISCORD_TOKEN.txt", "r") as code:
     TOKEN = code.readlines()[0]
 
 # client = discord.Client()  # way 1

--- a/src/bot.py
+++ b/src/bot.py
@@ -4,18 +4,7 @@ import random
 with open("DISCORD_TOKEN.txt", "r") as code:
     TOKEN = code.readlines()[0]
 
-# client = discord.Client()  # way 1
-
-# @client.event
-# async def on_ready():
-#     print(f'{client.user.name} has connected to Discord!')
-
-bot = commands.Bot(command_prefix='!')  # way 2, you cant use both ways
-
-
-@bot.command(name="hello", aliases=["hi", "hey", "hallo"])
-async def world(ctx):
-    await ctx.send('world!')
+bot = commands.Bot(command_prefix=',')
 
 
 @bot.command(name='roll_dice', help='Simulates rolling dice.')


### PR DESCRIPTION
Before, whenever a user ran the `!hello` command, `test` would appear on the stdout of the host. I removed that since it would be annoying for the host to constantly have `test` appear in their terminal, that's all.