### PR TITLE
add import os

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -3,6 +3,7 @@ import discord
 import requests
 import math
 import asyncio
+import os
 
 from grab_tio import Tio
 from time import sleep


### PR DESCRIPTION
We forgot to import the `os` library, even though we use it!