### PR TITLE
repl multiline + ``` support; fix negative timer issue

### DIFF
--- a/src/Cogs/TimerCog.py
+++ b/src/Cogs/TimerCog.py
@@ -4,79 +4,96 @@ import asyncio
 from discord.ext import commands
 
 from Cogs.VoiceCog import VoiceCog
-    
+
 
 class TimerCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.voiceCog = bot.get_cog('VoiceCog')
+        self.voiceCog = bot.get_cog("VoiceCog")
 
-    @commands.command(name='timer', brief='Pomodoro-esque timer for productivity!',
-                 description='Run a timer for x minutes and be alerted when your time is up.',
-                 aliases=['pomodoro', 'stopwatch'])
+    @commands.command(
+        name="timer",
+        brief="Pomodoro-esque timer for productivity!",
+        description="Run a timer for x minutes and be alerted when your time is up.",
+        aliases=["pomodoro", "stopwatch"],
+    )
     async def timer(self, ctx, minutes: float = 25.0, pause: float = 5.0):
-        try:
-            is_work = True
-            time = minutes * 60
+        if minutes >= 0:
+            try:
+                is_work = True
+                time = minutes * 60
+                embed = discord.Embed(
+                    title="Timer",
+                    description=f"Timer set for {math.floor(time / 60)} minutes and {int(float(time % 60))} seconds.",
+                    color=0x00FF00,
+                )
+                await ctx.send(embed=embed)
+
+                for x in range(int(time)):
+                    while time > 0:
+                        if time > 60:
+                            time -= 60
+                            await asyncio.sleep(60)
+                        else:
+                            await asyncio.sleep(time)
+                            time = 0
+
+                    if time == 0:
+                        if is_work:
+                            time = pause * 60
+                            is_work = False
+
+                            embed = discord.Embed(
+                                title="Work Time's Up!",
+                                description=f"{ctx.author.mention}\nYour timer has finished! Stop working, it is break time now!",
+                                color=0x00FF00,
+                            )
+
+                            message = await ctx.send(embed=embed)
+                            await self.voiceCog.join(ctx)
+                            await self.voiceCog.leave(ctx)
+
+                        else:
+                            time -= 1  # prevent infinite looping
+                            embed = discord.Embed(
+                                title="Break Time's Up!",
+                                description=f"{ctx.author.mention}\nYour timer has finished!\nNew timer?",
+                                color=0x00FF00,
+                            )
+
+                            await self.voiceCog.join(ctx)
+                            await self.voiceCog.leave(ctx)
+
+                            thumbsup = "\N{THUMBS UP SIGN}"
+                            thumbsdown = "\N{THUMBS DOWN SIGN}"
+
+                            message = await ctx.send(embed=embed)
+
+                            await message.add_reaction(thumbsup)
+                            await message.add_reaction(thumbsdown)
+
+                            def check(reaction, user):
+                                return (
+                                    user == ctx.author
+                                    and str(reaction.emoji) == thumbsup
+                                )
+
+                            try:
+                                # 10 seconds to check for reaction from user
+                                reaction = await self.bot.wait_for(
+                                    "reaction_add", timeout=10, check=check
+                                )
+                                await self.timer(ctx, minutes=minutes)
+                            except asyncio.TimeoutError:
+                                """If nobody gave a reaction"""
+                                pass
+
+            except:
+                embed = discord.Embed(title="Invalid Time Set")
+                await ctx.send(embed=embed)
+
+        else:
             embed = discord.Embed(
-                title="Timer",
-                description=f'Timer set for {math.floor(time / 60)} minutes and {int(float(time % 60))} seconds.',
-                color=0x00ff00)
-            await ctx.send(embed=embed)
-
-            for x in range(int(time)):
-                while time > 0:
-                    if time > 60:
-                        time -= 60
-                        await asyncio.sleep(60)
-                    else:
-                        await asyncio.sleep(time)
-                        time = 0
-
-                if time == 0:
-                    if is_work:
-                        time = pause * 60
-                        is_work = False
-
-                        embed = discord.Embed(
-                            title="Work Time's Up!",
-                            description=f'{ctx.author.mention}\nYour timer has finished! Stop working, it is break time now!',
-                            color=0x00ff00)
-
-                        message = await ctx.send(embed=embed)
-                        await self.voiceCog.join(ctx)
-                        await self.voiceCog.leave(ctx)
-
-                    else:
-                        time -= 1  # prevent infinite looping
-                        embed = discord.Embed(
-                            title="Break Time's Up!",
-                            description=f'{ctx.author.mention}\nYour timer has finished!\nNew timer?', color=0x00ff00)
-
-                        await self.voiceCog.join(ctx)
-                        await self.voiceCog.leave(ctx)
-
-                        thumbsup = '\N{THUMBS UP SIGN}'
-                        thumbsdown = '\N{THUMBS DOWN SIGN}'
-
-                        message = await ctx.send(embed=embed)
-
-                        await message.add_reaction(thumbsup)
-                        await message.add_reaction(thumbsdown)
-
-                        def check(reaction, user):
-                            return user == ctx.author and str(reaction.emoji) == thumbsup
-
-                        try:
-                            # 10 seconds to check for reaction from user
-                            reaction = await self.bot.wait_for('reaction_add', timeout=10, check=check)
-                            await self.timer(ctx, minutes=minutes)
-                        except asyncio.TimeoutError:
-                            """If nobody gave a reaction"""
-                            pass
-                    
-
-
-        except ValueError:
-            embed = discord.Embed(title='Invalid Time Set')
+                title="Who are you kidding? You can't set a negative timer :sweat_smile:"
+            )
             await ctx.send(embed=embed)

--- a/src/Cogs/TioCog.py
+++ b/src/Cogs/TioCog.py
@@ -3,20 +3,36 @@ import discord
 
 from Cogs.TioService.grab_tio import Tio
 
+
 class TioCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command(name='run', aliases=['evaluate', 'execute'], brief='Runs code in 600+ languages', description='.run <language> <code>')
+    @commands.command(
+        name="run",
+        aliases=["evaluate", "execute"],
+        brief="Runs code in 600+ languages",
+        description='.run <language> <code>. PLEASE NOTE: due to discord.py limitations, if you would like to run code that has double brackets - " in it, you must type a \ flipped backslash in front of it.',
+    )
     async def execute_code(self, ctx, lang: str, *args):
         query = " ".join(args[:])
+
+        query = query.replace(("```" + lang), "")
+        if lang == "python3":
+            query = query.replace('"', "'")  # will need to modify for other languages
+            query = query.replace("```python", "")
+
+        query = query.replace("`", "")
+        query = query.strip()
+        query = query.replace("\\n", ";")
 
         site = Tio()
         request = site.new_request(lang, query)
 
         embed = discord.Embed(
-            title=f'{lang} code evaluation', color=0x00f00, description='WITH TIO.RUN')
-        embed.add_field(name='**Result**', value=site.send(request))
+            title=f"{lang} code evaluation", color=0x00F00, description="WITH TIO.RUN"
+        )
+        embed.add_field(name="**Result**", value=site.send(request))
 
         await ctx.send(embed=embed)
 


### PR DESCRIPTION
Support for multiline and markdown formatting when compiling or performing REPL.

No longer getting negative timer issue, instead this cool-looking response: 
![image](https://user-images.githubusercontent.com/61620873/85054067-c4eaf080-b19b-11ea-86a0-b7f85d506291.png)
